### PR TITLE
Use hadolint to lint the dockerfile

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,17 @@
+name: Linting of Dockerfile
+on:
+  push:
+    paths:
+      - Dockerfile
+      - .github/workflows/hadolint.yml
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run hadolint on the primary Dockerfile
+        uses: burdzwastaken/hadolint-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HADOLINT_ACTION_DOCKERFILE_FOLDER: .

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Run hadolint on the primary Dockerfile
-        uses: burdzwastaken/hadolint-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HADOLINT_ACTION_DOCKERFILE_FOLDER: .
+      - name: Hadolint
+        uses: docker://docker.io/cardboardci/hadolint:latest
+        with:
+          args: "hadolint Dockerfile"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN wget -O hub.tgz "https://github.com/github/hub/releases/download/v${VERSION}/hub-linux-amd64-${VERSION}.tgz"
 RUN tar -xvf hub.tgz --strip-components 1 -C /usr/local;
 
+USER cardboardci
+
 ##
 ## Image Metadata
 ##


### PR DESCRIPTION
Enforce some constraints (+recommendations) on the image. Ensuring that things like versioning, references and installation remain consistent across all the project images. The most important requirement is that all of the images have pinned versions. When automated versioning is implemented, it'll be very good that all the dependencies already are versioned.

This PR supports enforcing linting recommendations for the Dockerfile when the file itself changes. Exceptions can be included by adding a hadolint.yml file at the root.